### PR TITLE
fix: update ProductIngredient state assignment

### DIFF
--- a/src/components/ProductIngredient/index.js
+++ b/src/components/ProductIngredient/index.js
@@ -15,7 +15,7 @@ export const ProductIngredient = (props) => {
   /**
    * Set current state
    */
-  const state = { id: ingredient.id, name: ingredient.name, selected: props.state.selected }
+  const state = { id: ingredient.id, name: ingredient.name, selected: props?.state?.selected }
 
   /**
    * Run onChange function with new state


### PR DESCRIPTION
The code changes in this commit update the assignment of the `state` variable in the `ProductIngredient` component. The `props.state.selected` value is now accessed using optional chaining (`props?.state?.selected`) to handle cases where `props.state` or `props.state.selected` may be undefined. This ensures that the component does not throw an error when accessing the `selected` property.