### PR TITLE
Refactor GoogleMaps component to allow marker popups and custom business click handling

### DIFF
--- a/src/components/GoogleMaps/index.js
+++ b/src/components/GoogleMaps/index.js
@@ -25,7 +25,8 @@ export const GoogleMaps = (props) => {
     deactiveAlerts,
     fallbackIcon,
     manualZoom,
-    avoidFitBounds
+    avoidFitBounds,
+    allowMarkerPopups
   } = props
 
   const [{ optimizeImage }] = useUtils()
@@ -95,7 +96,16 @@ export const GoogleMaps = (props) => {
         }
       } else {
         marker.addListener('click', () => {
-          onBusinessClick && onBusinessClick(locations[i]?.slug, locations[i])
+          if (locations[i]?.markerPopup && allowMarkerPopups) {
+            const infowindow = new window.google.maps.InfoWindow()
+            infowindow.setContent(locations[i]?.markerPopup)
+            infowindow.open(map, marker)
+            window.google.maps.event.addListenerOnce(infowindow, 'domready', () => {
+              document.getElementById(`order-now-${locations[i]?.id}`)?.addEventListener('click', () => locations[i]?.onBusinessCustomClick())
+            })
+          } else {
+            onBusinessClick && onBusinessClick(locations[i]?.slug, locations[i])
+          }
         })
         bounds.extend(marker.position)
         locationMarkers.push(marker)

--- a/src/contexts/OrderContext/index.js
+++ b/src/contexts/OrderContext/index.js
@@ -1304,11 +1304,11 @@ export const OrderProvider = ({
   }
 
   useEffect(() => {
-    if (session.loading || languageState.loading) return
+    if (session.loading || languageState.loading || !ordering?.project) return
     if (session.auth) {
       refreshOrderOptions()
     }
-  }, [session.auth, session.loading, languageState.loading])
+  }, [session.auth, session.loading, languageState.loading, ordering?.project])
 
   useEffect(() => {
     if (session.loading || configState.loading) return


### PR DESCRIPTION
Story: https://app.asana.com/0/1164464536714178/1208551975923129/f
- Added new prop `allowMarkerPopups` to enable marker popups in the GoogleMaps component.
- Updated the `onBusinessClick` event handler to check for marker popups and handle custom click events.
- Added logic to create an info window and display marker popups when enabled.
- Added event listener to handle custom click events within the marker popup.

Fix issue with OrderProvider useEffect dependencies

- Updated the useEffect dependencies in the OrderProvider component to include the `ordering.project` property.
- This ensures that the refreshOrderOptions function is called when the `ordering.project` property changes.