### PR TITLE
fix: Update session invalidation logic in OrderProvider to directly clear storage on web, preventing infinite reload loops on 401 errors.

### DIFF
--- a/src/contexts/OrderContext/index.js
+++ b/src/contexts/OrderContext/index.js
@@ -155,19 +155,25 @@ export const OrderProvider = ({
       }
       if (error) {
         if (status === 401 && session.auth) {
-          // Sesion invalida (p.ej. usuario deshabilitado desde el dashboard):
-          // se cierra sesion y se recarga la pagina para volver como invitado.
-          // Se hace return para no seguir disparando peticiones con un token
-          // ya invalido, y la recarga evita el bucle de re-renders que congela
-          // la pestaña. Tras recargar no hay token => no se llama orderOptions
-          // autenticado => no hay 401 => no se repite (sin loop de recargas).
-          await logout()
+          // Sesion invalida (p.ej. usuario deshabilitado desde el dashboard).
+          // En WEB: se limpia el storage directamente -SIN llamar logout(),
+          // que hace setState y alimenta la tormenta de re-renders que puede
+          // congelar la pestaña ANTES de alcanzar el reload- y se recarga.
+          // Tras recargar no hay token/user => sesion de invitado => no se
+          // llama orderOptions autenticado => no hay 401 (sin loop de recargas).
+          // El submodulo es compartido con apps React Native: el reload se
+          // hace SOLO en web; en el resto se cierra sesion normal con logout().
           const isWeb = typeof window !== 'undefined' &&
             typeof window.document !== 'undefined' &&
             typeof window.location?.reload === 'function'
           if (isWeb) {
+            await strategy.removeItem('token')
+            await strategy.removeItem('user')
+            await strategy.removeItem('device_code')
             window.location.reload()
+            return
           }
+          await logout()
           return
         }
         setAlert({ show: true, content: result, status })


### PR DESCRIPTION
Story: https://app.asana.com/1/306583973076188/project/1120945085835679/task/1214819082844165?focus=true