### PR TITLE
feat: Add mergeAssignRequestOrders utility to handle upserting logistic orders by ID in OrderListGroups component

### DIFF
--- a/src/components/OrderListGroups/index.js
+++ b/src/components/OrderListGroups/index.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, useRef } from 'react'
+import dayjs from 'dayjs'
 import { useSession } from '../../contexts/SessionContext'
 import { useApi } from '../../contexts/ApiContext'
 import { useWebsocket } from '../../contexts/WebsocketContext'
@@ -106,6 +107,7 @@ export const OrderListGroups = (props) => {
   const [orderLogisticUpdated, setOrderLogisticUpdated] = useState(null)
   const [recentlyReceivedMessage, setRecentlyReceivedMessage] = useState(null)
   const [loadingChangeOrder, setLoadingChangeOrder] = useState(false)
+  const resolvedAssignRequestsRef = useRef(new Map())
 
   const [ordersFiltered, setOrdersFiltered] = useState({
     orders: [],
@@ -833,8 +835,13 @@ export const OrderListGroups = (props) => {
         const order = logisticOrders?.orders?.find(order => order?.id === orderId)
         const newOrders = sortOrders(logisticOrders?.orders?.filter(_order => _order?.id !== orderId))
         setlogisticOrders({ ...logisticOrders, orders: newOrders })
+        resolvedAssignRequestsRef.current.set(orderId, order?.updated_at ?? order?.status_at ?? null)
         if (status === 1) {
           const acceptedOrder = order?.order ?? order
+          const acceptedOrders = acceptedOrder?.order_group?.orders?.length
+            ? acceptedOrder.order_group.orders
+            : [acceptedOrder].filter(Boolean)
+          acceptedOrders.forEach((o) => actionOrderToTab(o, getStatusById(o?.status), 'add'))
           if (PROJECTS_WITH_LOGISTIC_DEFAULT_ETA.includes(ordering?.project)) {
             const defaultEta = parseInt(t('LOGISTIC_DEFAULT_ETA_TIME', '10'), 10) || 10
             const targetOrderIds = acceptedOrder?.order_group?.orders?.length
@@ -1122,8 +1129,15 @@ export const OrderListGroups = (props) => {
     }
   }, [JSON.stringify(ordersGroup), socket?.socket, session])
 
+  const isStaleResolvedAssignRequest = (order) => {
+    if (!resolvedAssignRequestsRef.current.has(order?.id)) return false
+    const resolvedAt = resolvedAssignRequestsRef.current.get(order?.id)
+    return !resolvedAt || !order?.updated_at || !dayjs(order.updated_at).isAfter(dayjs(resolvedAt))
+  }
+
   const handleAddAssignRequest = useCallback(
     (order) => {
+      if (isStaleResolvedAssignRequest(order)) return
       setOrderLogisticAdded(order)
       const isSameEvent = orderLogisticAdded?.id === order?.id && orderLogisticAdded.status === order?.status
       if (!order?.locked && !isSameEvent) {
@@ -1131,7 +1145,7 @@ export const OrderListGroups = (props) => {
       }
       setlogisticOrders((prevState) => ({
         ...prevState,
-        orders: sortOrders(mergeAssignRequestOrders(prevState?.orders, order)) // upsert by id (dedups duplicates)
+        orders: sortOrders(mergeAssignRequestOrders(prevState?.orders, order))
       }))
       showToast(
         ToastType.Info,
@@ -1156,6 +1170,7 @@ export const OrderListGroups = (props) => {
 
   const handleUpdateAssignRequest = useCallback(
     (order) => {
+      if (isStaleResolvedAssignRequest(order)) return
       setOrderLogisticUpdated(order)
       const isSameEvent = orderLogisticUpdated?.id === order?.id && orderLogisticUpdated.status === order?.status
       if (!order?.locked && !isSameEvent) {

--- a/src/components/OrderListGroups/index.js
+++ b/src/components/OrderListGroups/index.js
@@ -7,6 +7,7 @@ import { useLanguage } from '../../contexts/LanguageContext'
 import { useEvent } from '../../contexts/EventContext'
 import { useConfig } from '../../contexts/ConfigContext'
 import { PROJECTS_WITH_LOGISTIC_DEFAULT_ETA } from '../../constants/logistic'
+import { mergeAssignRequestOrders } from './utils'
 
 export const OrderListGroups = (props) => {
   props = { ...defaultProps, ...props }
@@ -1130,12 +1131,7 @@ export const OrderListGroups = (props) => {
       }
       setlogisticOrders((prevState) => ({
         ...prevState,
-        orders: sortOrders([...prevState?.orders, order].filter((order, index, hash) => { // remove possibles duplicates
-          const val = JSON.stringify(order)
-          return index === hash.findIndex(_order => {
-            return JSON.stringify(_order) === val
-          })
-        }))
+        orders: sortOrders(mergeAssignRequestOrders(prevState?.orders, order)) // upsert by id (dedups duplicates)
       }))
       showToast(
         ToastType.Info,
@@ -1165,15 +1161,16 @@ export const OrderListGroups = (props) => {
       if (!order?.locked && !isSameEvent) {
         handleActionEvent('request_update', order)
       }
+      const isNewOrder = !logisticOrders?.orders?.some(_order => _order?.id === order?.id)
       setlogisticOrders(prevState => ({
         ...prevState,
-        orders: prevState?.orders?.some(_order => _order?.id === order?.id)
-          ? sortOrders([...prevState?.orders?.filter(_order => _order?.id !== order?.id), { ...prevState?.orders?.find(_order => _order?.id === order?.id), ...order }])
-          : sortOrders(prevState?.orders)
+        orders: sortOrders(mergeAssignRequestOrders(prevState?.orders, order))
       }))
       showToast(
         ToastType.Info,
-        t('SPECIFIC_LOGISTIC_ORDER_UPDATED', 'Your logisitc order number _NUMBER_ has updated').replace('_NUMBER_', order?.order?.id ?? order.id),
+        isNewOrder
+          ? t('SPECIFIC_LOGISTIC_ORDER_ORDERED', 'Logisitc order _NUMBER_ has been ordered').replace('_NUMBER_', order?.order?.id ?? order.id)
+          : t('SPECIFIC_LOGISTIC_ORDER_UPDATED', 'Your logisitc order number _NUMBER_ has updated').replace('_NUMBER_', order?.order?.id ?? order.id),
         1000
       )
     },

--- a/src/components/OrderListGroups/utils.js
+++ b/src/components/OrderListGroups/utils.js
@@ -1,0 +1,28 @@
+/**
+ * Upsert a logistic assign-request into the list, keyed by its `id`.
+ *
+ * - If an entry with the same `id` already exists, the incoming data is merged
+ *   over it (same behaviour as before for `request_update`).
+ * - If it does NOT exist yet, the incoming assign-request is appended instead of
+ *   being silently dropped.
+ *
+ * Why: during advanced-logistics driver reassignment (the "jump to next driver
+ * every N seconds" config) the assign-request id churns constantly. A
+ * `request_update` for a late-added grouped order (3rd onward) can arrive before
+ * its `request_register`, or target an id the app no longer holds. The previous
+ * update handler returned the list unchanged in that case, so the order stayed
+ * in "Accepted by business" (status 7) until a manual refresh. Upserting by id
+ * guarantees the order is never lost, and de-duplicating by id (instead of by
+ * full JSON) prevents duplicate cards when both events arrive for the same id.
+ *
+ * @param {Array<object>} orders current assign-request list
+ * @param {object} order incoming assign-request payload
+ * @returns {Array<object>} new list (never mutates the input)
+ */
+export const mergeAssignRequestOrders = (orders, order) => {
+  const list = Array.isArray(orders) ? orders : []
+  if (!order || order.id === undefined || order.id === null) return list
+  const exists = list.some(_order => _order?.id === order?.id)
+  if (!exists) return [...list, order]
+  return list.map(_order => (_order?.id === order?.id ? { ..._order, ...order } : _order))
+}


### PR DESCRIPTION
Story: https://app.asana.com/1/306583973076188/project/1164464536714178/task/1215306587497356?focus=true