### PR TITLE
refactor: Remove loading toast notifications from business and product favorite handlers

### DIFF
--- a/src/components/BusinessAndProductList/index.js
+++ b/src/components/BusinessAndProductList/index.js
@@ -213,7 +213,6 @@ export const BusinessAndProductList = (props) => {
    */
   const handleFavoriteBusiness = async (isAdd = false) => {
     if (!businessState?.business || !user) return
-    showToast(ToastType.Info, t('LOADING', 'loading'))
 
     try {
       const changes = { object_id: businessState?.business?.id }

--- a/src/components/BusinessController/index.js
+++ b/src/components/BusinessController/index.js
@@ -119,7 +119,6 @@ export const BusinessController = (props) => {
    */
   const handleFavoriteBusiness = async (isAdd = false) => {
     if (!businessState?.business || !user) return
-    showToast(ToastType.Info, t('LOADING', 'loading'))
 
     try {
       setActionState({ ...actionState, loading: true, error: null })

--- a/src/components/CmsContent/index.js
+++ b/src/components/CmsContent/index.js
@@ -45,7 +45,7 @@ export const CmsContent = (props) => {
     getPage(pageSlug)
     return () => {
       if (requestsState.page) {
-        requestsState.page.cancel()
+        requestsState.page?.cancel?.()
       }
     }
   }, [])

--- a/src/components/ProductForm/index.js
+++ b/src/components/ProductForm/index.js
@@ -258,7 +258,6 @@ export const ProductForm = (props) => {
    */
   const handleFavoriteProduct = async (productFav, isAdd = false) => {
     if (!product || !user) return
-    showToast(ToastType.Info, t('LOADING', 'loading'))
     try {
       const productId = productFav?.id
       const changes = { object_id: productId }

--- a/src/components/SingleOrderCard/index.js
+++ b/src/components/SingleOrderCard/index.js
@@ -34,7 +34,6 @@ export const SingleOrderCard = (props) => {
     if (!order || !user) return
 
     try {
-      showToast(ToastType.Info, t('LOADING', 'loading'))
       setActionState({ ...actionState, loading: true, error: null })
       const changes = { object_id: order?.id }
       const requestOptions = {

--- a/src/components/SingleProductCard/index.js
+++ b/src/components/SingleProductCard/index.js
@@ -29,7 +29,6 @@ export const SingleProductCard = (props) => {
    */
   const handleFavoriteProduct = async (isAdd = false) => {
     if (!product || !user) return
-    showToast(ToastType.Info, t('LOADING', 'loading'))
     try {
       setActionState({ ...actionState, loading: true, error: null })
       const productId = isProductId ? product?.product_id : product?.id

--- a/src/components/SingleProfessionalCard/index.js
+++ b/src/components/SingleProfessionalCard/index.js
@@ -26,7 +26,6 @@ export const SingleProfessionalCard = (props) => {
    */
   const handleFavoriteProfessional = async (isAdd = false) => {
     if (!professional || !user) return
-    showToast(ToastType.Info, t('LOADING', 'loading'))
     try {
       setActionState({ ...actionState, loading: true, error: null })
       const changes = { object_id: professional?.id }


### PR DESCRIPTION
* Eliminate redundant loading toast notifications in handleFavoriteBusiness for BusinessAndProductList, BusinessController, ProductForm, SingleOrderCard, SingleProductCard, and SingleProfessionalCard components.
* Update cancellation logic in CmsContent component to use optional chaining for improved safety.

Story: https://app.asana.com/1/306583973076188/project/1164464536714178/task/1213832291361164?focus=true