### PR TITLE
fix(OrderListGroups): update page size logic for order fetching based on status options

### DIFF
--- a/src/components/OrderListGroups/index.js
+++ b/src/components/OrderListGroups/index.js
@@ -395,7 +395,9 @@ export const OrderListGroups = (props) => {
       }
     }
 
-    const pageSize = paginationSettings.pageSize
+    const pageSize = options?.allStatusses
+      ? (paginationSettings.filteredPageSize ?? paginationSettings.pageSize)
+      : paginationSettings.pageSize
 
     try {
       if (options?.allStatusses) {
@@ -503,6 +505,7 @@ export const OrderListGroups = (props) => {
     try {
       const { content: { error, result, pagination } } = await getOrders({
         page: options?.allStatusses ? ordersFiltered.pagination.currentPage + 1 : ordersGroup[currentTabSelected].pagination.currentPage + 1,
+        pageSize: options?.allStatusses ? (paginationSettings.filteredPageSize ?? paginationSettings.pageSize) : paginationSettings.pageSize,
         orderStatus: options?.allStatusses ? null : ordersGroup[currentTabSelected]?.currentFilter,
         newFetch: true
       })


### PR DESCRIPTION
- Adjusted page size calculation to consider filtered page size when all statuses are selected.
- Ensured consistent pagination behavior in order fetching based on the updated options.

Story: https://app.asana.com/1/306583973076188/project/1164464536714178/task/1216209111429580?focus=true