### PR TITLE
fix(OrderDetails, WebsocketContext): streamline socket event handling and improve leave logic

### DIFF
--- a/src/components/OrderDetails/index.js
+++ b/src/components/OrderDetails/index.js
@@ -712,9 +712,7 @@ export const OrderDetails = (props) => {
       }
     })
     socket.on('tracking_driver', handleTrackingDriver)
-    if (!socket?.socket?._callbacks?.$update_order || socket?.socket?._callbacks?.$update_order?.find(func => func?.name !== 'handleUpdateOrderDetails')) {
-      socket.on('update_order', handleUpdateOrderDetails)
-    }
+    socket.on('update_order', handleUpdateOrderDetails)
     return () => {
       if (!isDisabledOrdersRoom && !props.disabledLeaveOrderSocket) socket.leave(getRoom('orders'))
       socket.off('update_order', handleUpdateOrderDetails)

--- a/src/contexts/WebsocketContext/socket.js
+++ b/src/contexts/WebsocketContext/socket.js
@@ -1,11 +1,22 @@
 import io from 'socket.io-client'
 
+const LEAVE_DEBOUNCE_MS = 500
+
 export class Socket {
   constructor ({ url, project, accessToken }) {
     this.url = url
     this.project = project
     this.accessToken = accessToken
     this.queue = []
+    this.pendingLeaves = {}
+  }
+
+  roomTarget (room) {
+    return typeof room === 'string' ? `${this.project}_${room}` : room
+  }
+
+  roomKey (room) {
+    return typeof room === 'string' ? `${this.project}_${room}` : JSON.stringify(room)
   }
 
   connect () {
@@ -32,7 +43,7 @@ export class Socket {
         } else if (item.action === 'leave') {
           this.leave(item.room)
         } else if (item.action === 'off') {
-          this.off(item.room)
+          this.off(item.event, item.func)
         }
       }
     })
@@ -49,11 +60,13 @@ export class Socket {
   }
 
   join (room) {
+    const key = this.roomKey(room)
+    if (this.pendingLeaves[key]) {
+      clearTimeout(this.pendingLeaves[key])
+      delete this.pendingLeaves[key]
+    }
     if (this.socket?.connected) {
-      this.socket.emit(
-        'join',
-        typeof room === 'string' ? `${this.project}_${room}` : room
-      )
+      this.socket.emit('join', this.roomTarget(room))
     } else {
       this.queue.push({ action: 'join', room })
     }
@@ -61,14 +74,16 @@ export class Socket {
   }
 
   leave (room) {
-    if (this.socket?.connected) {
-      this.socket.emit(
-        'leave',
-        typeof room === 'string' ? `${this.project}_${room}` : room
-      )
-    } else {
-      this.queue.push({ action: 'leave', room })
-    }
+    const key = this.roomKey(room)
+    if (this.pendingLeaves[key]) return this
+    this.pendingLeaves[key] = setTimeout(() => {
+      delete this.pendingLeaves[key]
+      if (this.socket?.connected) {
+        this.socket.emit('leave', this.roomTarget(room))
+      } else {
+        this.queue.push({ action: 'leave', room })
+      }
+    }, LEAVE_DEBOUNCE_MS)
     return this
   }
 


### PR DESCRIPTION
- Simplified the update_order event handling in OrderDetails by always listening for updates.
- Enhanced the leave method in the Socket class to debounce leave actions, preventing rapid consecutive calls.
- Introduced roomKey and roomTarget methods for better room management and consistency in socket operations.

Story: https://linear.app/finitless/issue/ORD-285/bug-issue-with-socket-connection