### PR TITLE
fix(OrderListGroups): add filtering logic to exclude specific statuses from order queries

### DIFF
--- a/src/components/OrderListGroups/index.js
+++ b/src/components/OrderListGroups/index.js
@@ -203,6 +203,16 @@ export const OrderListGroups = (props) => {
       options.query.where.push({ attribute: 'status', value: filtered.state })
     }
 
+    if (filtered?.excludeStatuses?.length) {
+      options.query.where.push({
+        attribute: 'status',
+        value: {
+          condition: '!=',
+          value: filtered.excludeStatuses
+        }
+      })
+    }
+
     if (filtered?.city) {
       options.query.where.push({
         attribute: 'business',


### PR DESCRIPTION
- Implemented logic to allow exclusion of specified statuses in order fetching.
- Enhanced query options to support dynamic filtering based on user-defined criteria.

Story: https://linear.app/finitless/issue/ORD-481/custom-driver-app-quickiedelivery