### PR TITLE
docs: document ordering-app-business-v26 as React Native consumer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,20 @@ Guidance for AI assistants working in **ordering-components** — the shared log
 
 **Repository:** [Finitless-com/ordering-components](https://github.com/Finitless-com/ordering-components) (formerly `OrderingPlus/components` / `OrderingX/components`)
 
-**Consumed as a git submodule** at `src/@/components` in marketplace apps:
+**Consumed as a git submodule** at `src/@/components` in consumer apps:
 
 | Consumer | Platform | Submodule path |
 |----------|----------|----------------|
 | [website-marketplace-v26](https://github.com/Finitless-com/website-marketplace-v26) | Web SPA (customers) | `src/@/components` |
 | [ordering-app-marketplace-v26](https://github.com/Finitless-com/ordering-app-marketplace-v26) | React Native (customers) | `src/@/components` |
 | [ordering-app-driver-26](https://github.com/Finitless-com/ordering-app-driver-26) | React Native (drivers) | `src/@/components` |
+| [ordering-app-business-v26](https://github.com/Finitless-com/ordering-app-business-v26) | React Native (business / stores) | `src/@/components` |
 
 Changes here affect **every app** that embeds this submodule — keep them generic and backward-compatible.
 
 ## What this repo is
 
-A **headless React layer**: controllers, React contexts, hooks, and the Ordering SDK. It contains **no app-specific UI skin**. Each consumer app (marketplace web/mobile, driver mobile) provides styled `UIComponent` implementations in its own `src/ui` folder.
+A **headless React layer**: controllers, React contexts, hooks, and the Ordering SDK. It contains **no app-specific UI skin**. Each consumer app (marketplace web/mobile, driver mobile, business mobile) provides styled `UIComponent` implementations in its own `src/ui` folder.
 
 **Stack:** React (peer >=16; consumers use 18), functional components, React Hooks, ES modules. ESLint standard + react. **No styled-components** in this repo.
 
@@ -29,7 +30,7 @@ A **headless React layer**: controllers, React contexts, hooks, and the Ordering
 | Platform | Barrel import | OrderingProvider | Storage strategy |
 |----------|---------------|------------------|------------------|
 | **Web** (website-marketplace-v26) | Deep-import `~components/components/Feature` — **never** `src/index.js` | `src/contexts/OrderingContext` | `WebStrategy` (localStorage) |
-| **React Native** (ordering-app-marketplace-v26, ordering-app-driver-26) | `@components` alias → `native/index.js` — **never** `src/index.js` | `native/src/contexts/OrderingContext` | `NativeStrategy` (AsyncStorage) |
+| **React Native** (ordering-app-marketplace-v26, ordering-app-driver-26, ordering-app-business-v26) | `@components` alias → `native/index.js` — **never** `src/index.js` | `native/src/contexts/OrderingContext` | `NativeStrategy` (AsyncStorage) |
 
 Both platforms share the same controllers in `src/components/*` and contexts in `src/contexts/*`. Platform-specific code lives only in `native/` (RN) and `webStrategy/` (web).
 
@@ -119,7 +120,7 @@ export const ExampleFeature = (props) => (
 )
 ```
 
-**React Native** — in ordering-app-marketplace-v26 or ordering-app-driver-26 (`src/ui/src/components/ExampleFeature/index.tsx`):
+**React Native** — in ordering-app-marketplace-v26, ordering-app-driver-26, or ordering-app-business-v26 (`src/ui/src/components/ExampleFeature/index.tsx`):
 
 ```tsx
 import { ExampleFeature as ExampleFeatureController } from '@components'
@@ -226,14 +227,16 @@ When adding a new export, add it to `index.js` for backward compatibility, but d
 
 ## Relationship to consumer apps
 
-| Layer | Web (website-marketplace-v26) | Mobile marketplace | Mobile driver |
-|-------|-------------------------------|--------------------|---------------|
-| Logic (this repo) | `src/@/components/src/` | `src/@/components/src/` | `src/@/components/src/` |
-| Presentation | `src/ui/` | `src/ui/` | `src/ui/` |
-| Routes / screens | `src/pages/`, `src/App.js` | `src/pages/`, `src/navigators/` | `src/pages/`, `src/navigators/` |
-| Worker/SEO | `worker/` | N/A | N/A |
+| Layer | Web (website-marketplace-v26) | Mobile marketplace | Mobile driver | Mobile business |
+|-------|-------------------------------|--------------------|---------------|-----------------|
+| Logic (this repo) | `src/@/components/src/` | `src/@/components/src/` | `src/@/components/src/` | `src/@/components/src/` |
+| Presentation | `src/ui/` | `src/ui/` | `src/ui/` | `src/ui/` |
+| Routes / screens | `src/pages/`, `src/App.js` | `src/pages/`, `src/navigators/` | `src/pages/`, `src/navigators/` | `src/pages/`, `src/navigators/` |
+| Worker/SEO | `worker/` | N/A | N/A | N/A |
 
 **Driver app note:** ordering-app-driver-26 reuses the same controller pattern but wires driver-specific skins (`OrdersListManager`, `AcceptOrRejectOrder`, `DriverMap`, `NewOrderNotification`, etc.) and passes driver order action keys (`acceptByDriver`, `rejectByDriver`, …) from pages. Do not add driver-only presentation here.
+
+**Business app note:** ordering-app-business-v26 reuses the same controller pattern but wires business/store skins (`OrdersListManager`, `OrdersOption`, `OrderDetails/Business`, `StoresList`, `PrinterSettings`, `TicketPreview`, etc.) and passes business order action keys (`acceptByBusiness`, `rejectByBusiness`) plus `isBusinessApp: true` and `allowedLevels: [0, 2]` from pages. Do not add business-only presentation here.
 
 When working **inside a consumer repo's submodule checkout**, treat edits as ordering-components PRs. Each consumer's `CLAUDE.md` forbids casual submodule edits — coordinate cross-repo changes explicitly.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ git clone --recursive https://github.com/Finitless-com/website-marketplace-v26.g
 git clone --recursive https://github.com/Finitless-com/ordering-app-marketplace-v26.git
 # or
 git clone --recursive https://github.com/Finitless-com/ordering-app-driver-26.git
+# or
+git clone --recursive https://github.com/Finitless-com/ordering-app-business-v26.git
 ```
 
 Once added, you can import the components directly from the submodule. This allows you to keep your project and these components separate, making updates and maintenance easier.


### PR DESCRIPTION
## Summary
- Add ordering-app-business-v26 to the consumer apps table and RN wiring notes in CLAUDE.md
- Document business-app action keys / skins so LLMs do not confuse this consumer with driver or marketplace
- Include the business app clone example in README.md

## Test plan
- [ ] Confirm CLAUDE.md consumer table lists all four apps
- [ ] Confirm README clone examples include ordering-app-business-v26


Made with [Cursor](https://cursor.com)