### PR TITLE
feat: add handleUpdateLogisticOrdersEta function to manage delivery times for accepted logistic orders

### DIFF
--- a/src/components/OrderDetails/__tests__/OrderDetails.test.jsx
+++ b/src/components/OrderDetails/__tests__/OrderDetails.test.jsx
@@ -182,10 +182,29 @@ describe('OrderDetails', () => {
 
   it('rejects logistic assign request', async () => {
     renderController(OrderDetails, { orderId: 101, order: orders.sampleOrder })
+    let result
     await act(async () => {
-      await lastControllerProps.handleClickLogisticOrder(2, 77, { id: 77 })
+      result = await lastControllerProps.handleClickLogisticOrder(2, 77, { id: 77 })
     })
     expect(orders.mockShowToast).toHaveBeenCalled()
+    expect(result).toEqual({ error: false })
+  })
+
+  it('returns the accepted orders so the UI can ask for a delivery time', async () => {
+    renderController(OrderDetails, { orderId: 101, order: orders.sampleOrder })
+    let result
+    await act(async () => {
+      result = await lastControllerProps.handleClickLogisticOrder(1, 77, { id: 101 })
+    })
+    expect(result).toMatchObject({ error: false, orderIds: [101], defaultEta: null })
+  })
+
+  it('saves the delivery time on the orders of an accepted assign request', async () => {
+    renderController(OrderDetails, { orderId: 101, order: orders.sampleOrder })
+    await act(async () => {
+      await lastControllerProps.handleUpdateLogisticOrdersEta([101], 25)
+    })
+    expect(orders.mockOrderSave).toHaveBeenCalledWith({ delivered_in: 25, id: 101 })
   })
 
   it('handles websocket order and driver tracking updates', async () => {

--- a/src/components/OrderDetails/index.js
+++ b/src/components/OrderDetails/index.js
@@ -49,6 +49,26 @@ export const OrderDetails = (props) => {
    * Method to accept or reject a logistic order
    */
 
+  /**
+   * Save the delivery time (in minutes) on every order of an accepted logistic assign request
+   * @param {Array} orderIds ids of the orders to update
+   * @param {Number} deliveredIn delivery time in minutes
+   */
+  const handleUpdateLogisticOrdersEta = async (orderIds, deliveredIn) => {
+    const ids = (orderIds ?? []).filter(Boolean)
+    const parsedEta = parseInt(deliveredIn, 10)
+    if (!ids.length || isNaN(parsedEta)) return []
+    const setOrderEta = async (id) => {
+      try {
+        const { content: { result, error } } = await ordering.setAccessToken(accessToken).orders(id).save({ delivered_in: parsedEta, id })
+        return error ? null : result
+      } catch {
+        return null
+      }
+    }
+    return await Promise.all(ids.map(id => setOrderEta(id)))
+  }
+
   const handleClickLogisticOrder = async (status, orderId, orders) => {
     try {
       const response = await fetch(`${ordering.root}/drivers/${user?.id}/assign_requests/${orderId}`, {
@@ -62,37 +82,34 @@ export const OrderDetails = (props) => {
       const { result, error } = await response.json()
       if (!error) {
         if (status === 1) {
+          const groupOrders = orders?.order_group?.orders ?? orders?.order?.order_group?.orders
+          const targetOrderIds = (groupOrders?.length
+            ? groupOrders.map(o => o?.id)
+            : [orders?.order?.id ?? orders?.id]
+          ).filter(Boolean)
+          let defaultEta = null
           if (PROJECTS_WITH_LOGISTIC_DEFAULT_ETA.includes(ordering?.project)) {
-            const defaultEta = parseInt(t('LOGISTIC_DEFAULT_ETA_TIME', '10'), 10) || 10
-            const groupOrders = orders?.order_group?.orders ?? orders?.order?.order_group?.orders
-            const targetOrderIds = (groupOrders?.length
-              ? groupOrders.map(o => o?.id)
-              : [orders?.order?.id ?? orders?.id]
-            ).filter(Boolean)
-            try {
-              await Promise.all(
-                targetOrderIds.map(id =>
-                  ordering.setAccessToken(accessToken).orders(id).save({ delivered_in: defaultEta })
-                )
-              )
-            } catch (e) {
-            }
+            defaultEta = parseInt(t('LOGISTIC_DEFAULT_ETA_TIME', '10'), 10) || 10
+            await handleUpdateLogisticOrdersEta(targetOrderIds, defaultEta)
           }
           showToast(
             ToastType.Success,
             t('SPECIFIC_ORDER_ACCEPTED', 'Your accepted the order number _NUMBER_').replace('_NUMBER_', orders?.id)
           )
+          return { error: false, order: orders?.order ?? orders, orderIds: targetOrderIds, defaultEta }
         } else {
           showToast(
             ToastType.Info,
             t('SPECIFIC_ORDER_REJECTED', 'Your rejected the order number _NUMBER_').replace('_NUMBER_', orders?.id)
           )
         }
-        return
+        return { error: false }
       }
       showToast(ToastType.Error, result)
+      return { error: true, result }
     } catch (err) {
       showToast(ToastType.Error, err.message)
+      return { error: true, result: err.message }
     }
   }
 
@@ -791,6 +808,7 @@ export const OrderDetails = (props) => {
           handleRemoveCart={handleRemoveCart}
           cartState={cartState}
           handleClickLogisticOrder={handleClickLogisticOrder}
+          handleUpdateLogisticOrdersEta={handleUpdateLogisticOrdersEta}
           loadMessages={loadMessages}
           showReservationAlert={showReservationAlert}
           setShowReservationAlert={setShowReservationAlert}

--- a/src/components/OrderListGroups/__tests__/OrderListGroups.test.jsx
+++ b/src/components/OrderListGroups/__tests__/OrderListGroups.test.jsx
@@ -217,10 +217,33 @@ describe('OrderListGroups', () => {
       lastControllerProps.setCurrentTabSelected('logisticOrders')
     })
     await waitFor(() => expect(lastControllerProps.logisticOrders.orders).toHaveLength(1))
+    let result
     await act(async () => {
-      await lastControllerProps.handleClickLogisticOrder(1, 77)
+      result = await lastControllerProps.handleClickLogisticOrder(1, 77)
     })
     expect(orders.mockShowToast).toHaveBeenCalled()
+    expect(result).toMatchObject({ error: false, orderIds: [101], defaultEta: null })
+  })
+
+  it('saves the delivery time on the orders of an accepted assign request', async () => {
+    renderController(OrderListGroups, { isNetConnected: true })
+    await waitFor(() => expect(lastControllerProps.ordersGroup.pending.fetched).toBe(true))
+    let result
+    await act(async () => {
+      result = await lastControllerProps.handleUpdateLogisticOrdersEta([101], 25)
+    })
+    expect(orders.mockOrderSave).toHaveBeenCalledWith({ delivered_in: 25, id: 101 })
+    expect(result).toHaveLength(1)
+  })
+
+  it('skips the delivery time save when there is no order or no time', async () => {
+    renderController(OrderListGroups, { isNetConnected: true })
+    await waitFor(() => expect(lastControllerProps.ordersGroup.pending.fetched).toBe(true))
+    await act(async () => {
+      await lastControllerProps.handleUpdateLogisticOrdersEta([], 25)
+      await lastControllerProps.handleUpdateLogisticOrdersEta([101], null)
+    })
+    expect(orders.mockOrderSave).not.toHaveBeenCalled()
   })
 
   it('filters by driver, paymethod, and date range', async () => {

--- a/src/components/OrderListGroups/index.js
+++ b/src/components/OrderListGroups/index.js
@@ -832,6 +832,26 @@ export const OrderListGroups = (props) => {
     }
   }
 
+  /**
+   * Save the delivery time (in minutes) on every order of an accepted logistic assign request
+   * @param {Array} orderIds ids of the orders to update
+   * @param {Number} deliveredIn delivery time in minutes
+   */
+  const handleUpdateLogisticOrdersEta = async (orderIds, deliveredIn) => {
+    const ids = (orderIds ?? []).filter(Boolean)
+    const parsedEta = parseInt(deliveredIn, 10)
+    if (!ids.length || isNaN(parsedEta)) return []
+    const setOrderEta = async (id) => {
+      try {
+        const { content: { result, error } } = await ordering.setAccessToken(session?.token).orders(id).save({ delivered_in: parsedEta, id })
+        return error ? null : result
+      } catch {
+        return null
+      }
+    }
+    return await Promise.all(ids.map(id => setOrderEta(id)))
+  }
+
   const handleClickLogisticOrder = async (status, orderId) => {
     try {
       setLoadingChangeOrder(true)
@@ -855,21 +875,14 @@ export const OrderListGroups = (props) => {
             ? acceptedOrder.order_group.orders
             : [acceptedOrder].filter(Boolean)
           acceptedOrders.forEach((o) => actionOrderToTab(o, getStatusById(o?.status), 'add'))
+          const targetOrderIds = (acceptedOrder?.order_group?.orders?.length
+            ? acceptedOrder.order_group.orders.map(o => o?.id)
+            : [acceptedOrder?.id]
+          ).filter(Boolean)
+          let defaultEta = null
           if (PROJECTS_WITH_LOGISTIC_DEFAULT_ETA.includes(ordering?.project)) {
-            const defaultEta = parseInt(t('LOGISTIC_DEFAULT_ETA_TIME', '10'), 10) || 10
-            const targetOrderIds = acceptedOrder?.order_group?.orders?.length
-              ? acceptedOrder.order_group.orders.map(o => o?.id)
-              : [acceptedOrder?.id]
-            try {
-              await Promise.all(
-                targetOrderIds
-                  .filter(Boolean)
-                  .map(id =>
-                    ordering.setAccessToken(session?.token).orders(id).save({ delivered_in: defaultEta })
-                  )
-              )
-            } catch (e) {
-            }
+            defaultEta = parseInt(t('LOGISTIC_DEFAULT_ETA_TIME', '10'), 10) || 10
+            await handleUpdateLogisticOrdersEta(targetOrderIds, defaultEta)
           }
 
           handleClickOrder(acceptedOrder)
@@ -877,18 +890,21 @@ export const OrderListGroups = (props) => {
             ToastType.Success,
             t('SPECIFIC_ORDER_ACCEPTED', 'Your accepted the order number _NUMBER_').replace('_NUMBER_', order?.order?.id ?? order?.id)
           )
+          return { error: false, order: acceptedOrder, orderIds: targetOrderIds, defaultEta }
         } else {
           showToast(
             ToastType.Info,
             t('SPECIFIC_ORDER_REJECTED', 'Your rejected the order number _NUMBER_').replace('_NUMBER_', order?.order?.id ?? order?.id)
           )
         }
-        return
+        return { error: false }
       }
       showToast(ToastType.Error, result)
+      return { error: true, result }
     } catch (err) {
       setlogisticOrders({ ...logisticOrders, error: err.message })
       showToast(ToastType.Error, err.message)
+      return { error: true, result: err.message }
     } finally {
       setLoadingChangeOrder(false)
     }
@@ -1310,6 +1326,7 @@ export const OrderListGroups = (props) => {
           loadMoreOrders={loadMoreOrders}
           handleClickOrder={handleClickOrder}
           handleClickLogisticOrder={handleClickLogisticOrder}
+          handleUpdateLogisticOrdersEta={handleUpdateLogisticOrdersEta}
           filtered={filtered}
           onFiltered={setFiltered}
           handleChangeOrderStatus={handleChangeOrderStatus}


### PR DESCRIPTION
- Implemented handleUpdateLogisticOrdersEta to save delivery times for multiple orders.
- Updated handleClickLogisticOrder to utilize the new function for setting default ETA.
- Enhanced tests to cover new functionality, including saving delivery times and handling edge cases.

Story: https://linear.app/finitless/issue/ORD-1115/bug-driver-app-v26-delivery-time-timer-is-missing-when-an-order-is