### PR TITLE
[ORD-1206] 🐞 Bug: Incorrect currency symbol ($ instead of SRD)

### DIFF
--- a/src/components/OrderDetails/__tests__/OrderDetails.test.jsx
+++ b/src/components/OrderDetails/__tests__/OrderDetails.test.jsx
@@ -7,6 +7,8 @@ const orders = vi.hoisted(() => {
   return createCustomerOrdersTestContext(vi)
 })
 
+const mockParsePrice = vi.hoisted(() => vi.fn(price => `SRD ${price.toFixed(2)}`))
+
 vi.mock('../../../contexts/EventContext', async (importOriginal) => {
   const actual = await importOriginal()
   return {
@@ -52,6 +54,10 @@ vi.mock('../../../contexts/WebsocketContext', () => ({
   useWebsocket: () => orders.mockSocket
 }))
 
+vi.mock('../../../contexts/UtilsContext', () => ({
+  useUtils: () => [{ parsePrice: mockParsePrice }]
+}))
+
 import { OrderDetails } from '../index'
 
 describe('OrderDetails', () => {
@@ -67,7 +73,8 @@ describe('OrderDetails', () => {
 
   it('formats prices for display', () => {
     renderController(OrderDetails, { orderId: 101, order: orderProp })
-    expect(lastControllerProps.formatPrice(19.5)).toBe('$ 19.50')
+    expect(lastControllerProps.formatPrice(19.5)).toBe('SRD 19.50')
+    expect(mockParsePrice).toHaveBeenCalledWith(19.5)
   })
 
   it('merges dataToSave without hitting the API', async () => {

--- a/src/components/OrderDetails/index.js
+++ b/src/components/OrderDetails/index.js
@@ -7,6 +7,7 @@ import { useToast, ToastType } from '../../contexts/ToastContext'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { useEvent } from '../../contexts/EventContext'
 import { useOrder } from '../../contexts/OrderContext'
+import { useUtils } from '../../contexts/UtilsContext'
 import { PROJECTS_WITH_LOGISTIC_DEFAULT_ETA } from '../../constants/logistic'
 
 export const OrderDetails = (props) => {
@@ -31,6 +32,7 @@ export const OrderDetails = (props) => {
   const [, t] = useLanguage()
   const [events] = useEvent()
   const [{ carts }, { reorder, clearCart }] = useOrder()
+  const [{ parsePrice }] = useUtils()
 
   const [orderState, setOrderState] = useState({ order: props.order ?? null, businessData: {}, loading: !props.order, error: null })
   const [drivers, setDrivers] = useState({ drivers: [], loadingDriver: false, error: null })
@@ -132,7 +134,7 @@ export const OrderDetails = (props) => {
    * Method to format a price number
    * @param {Number} price
    */
-  const formatPrice = price => price && `$ ${price.toFixed(2)}`
+  const formatPrice = price => price && parsePrice(price)
 
   /**
    * Method to Load message for first time

--- a/src/components/OrdersDashboardComponents/OrderDetails/__tests__/OrderDetails.test.jsx
+++ b/src/components/OrdersDashboardComponents/OrderDetails/__tests__/OrderDetails.test.jsx
@@ -7,6 +7,8 @@ const d1 = vi.hoisted(() => {
   return createDashboardOrdersTestContext(vi)
 })
 
+const mockParsePrice = vi.hoisted(() => vi.fn(price => `SRD ${price.toFixed(2)}`))
+
 vi.mock('../../../../contexts/EventContext', async (importOriginal) => {
   const actual = await importOriginal()
   return {
@@ -23,6 +25,10 @@ vi.mock('../../../../contexts/ApiContext', () => ({
   useApi: () => [d1.mockOrdering]
 }))
 
+vi.mock('../../../../contexts/UtilsContext', () => ({
+  useUtils: () => [{ parsePrice: mockParsePrice }]
+}))
+
 import { OrderDetails } from '../index'
 
 describe('OrderDetails', () => {
@@ -35,7 +41,8 @@ describe('OrderDetails', () => {
       isDisableLoadMessages: true
     })
     expect(lastControllerProps.order.order).toEqual(d1.sampleOrder)
-    expect(lastControllerProps.formatPrice(12.5)).toBe('$ 12.50')
+    expect(lastControllerProps.formatPrice(12.5)).toBe('SRD 12.50')
+    expect(mockParsePrice).toHaveBeenCalledWith(12.5)
   })
 
   it('updates order status via API', async () => {

--- a/src/components/OrdersDashboardComponents/OrderDetails/index.js
+++ b/src/components/OrdersDashboardComponents/OrderDetails/index.js
@@ -6,6 +6,7 @@ import { useWebsocket } from '../../../contexts/WebsocketContext'
 import { useEvent } from '../../../contexts/EventContext'
 import { useLanguage } from '../../../contexts/LanguageContext'
 import { useToast, ToastType } from '../../../contexts/ToastContext'
+import { useUtils } from '../../../contexts/UtilsContext'
 
 export const OrderDetails = (props) => {
   const {
@@ -24,6 +25,7 @@ export const OrderDetails = (props) => {
   const [events] = useEvent()
   const [, t] = useLanguage()
   const [, { showToast }] = useToast()
+  const [{ parsePrice }] = useUtils()
 
   const [orderState, setOrderState] = useState({ order: null, loading: !props.order, error: null })
   const [messageErrors, setMessageErrors] = useState({ status: null, loading: false, error: null })
@@ -39,7 +41,7 @@ export const OrderDetails = (props) => {
    * Method to format a price number
    * @param {Number} price
    */
-  const formatPrice = price => price && `$ ${price.toFixed(2)}`
+  const formatPrice = price => price && parsePrice(price)
 
   /**
    * Method to Load message for first time

--- a/src/contexts/UtilsContext/__tests__/UtilsContext.test.jsx
+++ b/src/contexts/UtilsContext/__tests__/UtilsContext.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+const mocks = vi.hoisted(() => ({
+  configs: {}
+}))
+
+vi.mock('../../ConfigContext', () => ({
+  useConfig: () => [{ configs: mocks.configs }]
+}))
+
+vi.mock('../../LanguageContext', () => ({
+  useLanguage: () => [{ loading: true }, (_key, fallback) => fallback]
+}))
+
+vi.mock('../../ApiContext', () => ({
+  useApi: () => [{}]
+}))
+
+vi.mock('../../EventContext', () => ({
+  useEvent: () => [{ on: vi.fn(), off: vi.fn() }]
+}))
+
+import { UtilsProviders, useUtils } from '../index'
+
+const baseConfigs = {
+  format_number_decimal_length: { value: 2 },
+  format_number_decimal_separator: { value: ',' },
+  format_number_thousand_separator: { value: '.' },
+  currency_position: { value: 'left' }
+}
+
+const strategy = {
+  getItem: () => new Promise(() => {})
+}
+
+const PriceConsumer = ({ onReady }) => {
+  const [{ parsePrice }] = useUtils()
+  onReady(parsePrice)
+  return null
+}
+
+describe('UtilsContext price formatting', () => {
+  beforeEach(() => {
+    mocks.configs = { ...baseConfigs }
+  })
+
+  it('prioritizes the configured display currency over an order currency symbol', () => {
+    mocks.configs.format_number_currency = { value: 'SRD' }
+    let parsePrice
+
+    render(
+      <UtilsProviders strategy={strategy}>
+        <PriceConsumer onReady={value => { parsePrice = value }} />
+      </UtilsProviders>
+    )
+
+    expect(parsePrice(1617, { currency: '$', currencyPosition: 'right' })).toBe('SRD 1.617,00')
+  })
+
+  it('uses the requested currency as a fallback when no display currency is configured', () => {
+    delete mocks.configs.currency_position
+    let parsePrice
+
+    render(
+      <UtilsProviders strategy={strategy}>
+        <PriceConsumer onReady={value => { parsePrice = value }} />
+      </UtilsProviders>
+    )
+
+    expect(parsePrice(1617, { currency: '€', currencyPosition: 'right' })).toBe('1.617,00 €')
+  })
+})

--- a/src/contexts/UtilsContext/index.js
+++ b/src/contexts/UtilsContext/index.js
@@ -138,8 +138,8 @@ export const UtilsProviders = ({ children, strategy }) => {
         decimal: options?.decimal || configState.configs.format_number_decimal_length?.value || 2,
         separator: options?.separator || configState.configs.format_number_decimal_separator?.value || ',',
         thousand: options?.thousand || configState.configs.format_number_thousand_separator?.value || '.',
-        currency: options?.currency || configState.configs.format_number_currency?.value || '$',
-        currencyPosition: options?.currencyPosition || configState.configs.currency_position?.value || 'left'
+        currency: configState.configs.format_number_currency?.value || options?.currency || '$',
+        currencyPosition: configState.configs.currency_position?.value || options?.currencyPosition || 'left'
       }
       let number = parseNumber(convertedValue, formatNumber)
       if (formatNumber.currencyPosition?.toLowerCase() === 'left') {


### PR DESCRIPTION
Fixes ORD-1206

## Summary
- prioritize the configured platform currency symbol and position in shared price formatting
- replace legacy hardcoded dollar formatting in customer and dashboard order controllers
- add regression coverage for configured currency precedence

## Test Plan
- [x] Run shared test suite
- [x] Run lint checks
- [x] Verify `SRD` wins over order-provided `$`

## Demo
https://d.pr/i/0W3CQ3

Made with [Cursor](https://cursor.com)