### PR TITLE
Expose CMS page SEO metadata to consumers [ORD-1266]

### DIFF
--- a/src/components/CmsContent/__tests__/CmsContent.test.jsx
+++ b/src/components/CmsContent/__tests__/CmsContent.test.jsx
@@ -1,6 +1,7 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { waitFor } from '@testing-library/react'
-import { renderController, lastControllerProps } from '../../../__tests__/helpers/renderController'
+import { ControllerUI, renderController, lastControllerProps } from '../../../__tests__/helpers/renderController'
 
 const acms = vi.hoisted(() => {
   const { createAnalyticsCmsTestContext } = require('../../../__tests__/helpers/analyticsCmsTestHelpers')
@@ -22,6 +23,43 @@ describe('CmsContent', () => {
       expect(lastControllerProps.cmsState.loading).toBe(false)
     })
     expect(lastControllerProps.cmsState.body).toBe('<p>CMS page</p>')
+  })
+
+  it('exposes CMS page SEO metadata after loading', async () => {
+    const onChangeMetaTag = vi.fn()
+    acms.mockPagesGet.mockResolvedValueOnce({
+      content: {
+        error: false,
+        result: {
+          body: '<p>CMS page</p>',
+          seo_title: 'About our marketplace',
+          seo_description: 'Learn more about our marketplace.'
+        }
+      }
+    })
+
+    renderController(CmsContent, { pageSlug: 'about-us', onChangeMetaTag })
+
+    await waitFor(() => {
+      expect(onChangeMetaTag).toHaveBeenCalledWith(
+        'About our marketplace',
+        'Learn more about our marketplace.'
+      )
+    })
+  })
+
+  it('reloads CMS content when the page slug changes', async () => {
+    const { rerender } = renderController(CmsContent, { pageSlug: 'about-us' })
+
+    await waitFor(() => {
+      expect(acms.mockOrdering.pages).toHaveBeenCalledWith('about-us')
+    })
+
+    rerender(<CmsContent UIComponent={ControllerUI} pageSlug='contact-us' />)
+
+    await waitFor(() => {
+      expect(acms.mockOrdering.pages).toHaveBeenCalledWith('contact-us')
+    })
   })
 
   it('calls onNotFound when page fetch fails', async () => {

--- a/src/components/CmsContent/index.js
+++ b/src/components/CmsContent/index.js
@@ -9,7 +9,8 @@ export const CmsContent = (props) => {
   const {
     UIComponent,
     pageSlug,
-    onNotFound
+    onNotFound,
+    onChangeMetaTag
   } = props
 
   /**
@@ -30,6 +31,7 @@ export const CmsContent = (props) => {
       setCmsState({ ...cmsState, loading: false })
       if (!error) {
         setCmsState({ ...cmsState, body: result.body })
+        onChangeMetaTag && onChangeMetaTag(result.seo_title, result.seo_description)
       } else {
         setCmsState({ ...cmsState, error: result })
         onNotFound && onNotFound(pageSlug)
@@ -48,7 +50,7 @@ export const CmsContent = (props) => {
         requestsState.page?.cancel?.()
       }
     }
-  }, [])
+  }, [pageSlug])
 
   return (
     <>
@@ -66,5 +68,8 @@ CmsContent.propTypes = {
   /**
    * UI Component, this must be containt all graphic elements and use parent props
    */
-  UIComponent: PropTypes.elementType
+  UIComponent: PropTypes.elementType,
+  pageSlug: PropTypes.string,
+  onNotFound: PropTypes.func,
+  onChangeMetaTag: PropTypes.func
 }


### PR DESCRIPTION
Fixes ORD-1266

## Summary
- expose CMS `seo_title` and `seo_description` through `onChangeMetaTag`
- refetch CMS content when the page slug changes during SPA navigation
- add regression coverage for metadata exposure and slug changes

## Test plan
- [x] Run focused `CmsContent` tests
- [x] Run ESLint
- [ ] Confirm website consumers can apply CMS metadata to Helmet

Made with [Cursor](https://cursor.com)