### PR TITLE
Backport GA4 analytics support [ORD-1193]

### DIFF
--- a/src/components/Analitycs/__tests__/Analytics.test.jsx
+++ b/src/components/Analitycs/__tests__/Analytics.test.jsx
@@ -36,8 +36,8 @@ describe('Analytics', () => {
     expect(getByTestId('child')).toBeInTheDocument()
   })
 
-  it('loads analytics script for measurement-style track ids', async () => {
-    window.ga = vi.fn()
+  it('tracks GA4 events when measurement id is provided', async () => {
+    window.gtag = vi.fn()
     let eventsRef = null
 
     render(
@@ -49,7 +49,7 @@ describe('Analytics', () => {
       </EventProvider>
     )
 
-    const script = document.getElementById('google-analytics-sdk')
+    const script = document.getElementById('google-analytics-gtag')
     expect(script).toBeTruthy()
     script.onload()
 
@@ -59,11 +59,22 @@ describe('Analytics', () => {
 
     eventsRef.emit('change_view', { page: '/menu' })
     eventsRef.emit('product_clicked', { id: 1, name: 'Burger', category_id: 2, price: 9.5 })
+    eventsRef.emit('product_added', { id: 1, name: 'Burger', category_id: 2, price: 9.5, quantity: 2 })
     eventsRef.emit('userLogin', { id: 42 })
+    eventsRef.emit('order_placed', {
+      id: 99,
+      total: '20',
+      tax_total: '2',
+      delivery_zone_price: '3',
+      currency: 'USD',
+      business: { name: 'Test restaurant' }
+    })
 
-    expect(window.ga).toHaveBeenCalledWith('set', 'page', '/menu')
-    expect(window.ga).toHaveBeenCalledWith('ec:addProduct', expect.any(Object))
-    expect(window.ga).toHaveBeenCalledWith('set', 'userId', 42)
+    expect(window.gtag).toHaveBeenCalledWith('event', 'page_view', expect.any(Object))
+    expect(window.gtag).toHaveBeenCalledWith('event', 'select_item', expect.any(Object))
+    expect(window.gtag).toHaveBeenCalledWith('event', 'add_to_cart', expect.any(Object))
+    expect(window.gtag).toHaveBeenCalledWith('config', 'G-TEST123', { user_id: '42' })
+    expect(window.gtag).toHaveBeenCalledWith('event', 'purchase', expect.any(Object))
   })
 
   it('tracks Universal Analytics events for legacy track ids', async () => {

--- a/src/components/Analitycs/index.js
+++ b/src/components/Analitycs/index.js
@@ -1,35 +1,74 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useEvent } from '../../contexts/EventContext'
 import PropTypes from 'prop-types'
+
+const GA4_SCRIPT_ID = 'google-analytics-gtag'
+const UA_SCRIPT_ID = 'google-analytics-sdk'
+
+const isGa4MeasurementId = (id) => typeof id === 'string' && id.startsWith('G-')
+
+const isDisabledTrackId = (id) => !id || id === '0'
 
 export const Analytics = (props) => {
   const {
     trackId,
     children
   } = props
-
   const [events] = useEvent()
   const [analyticsReady, setAnalyticsReady] = useState(false)
 
   useEffect(() => {
-    if (!trackId) {
+    if (isDisabledTrackId(trackId)) {
       return
     }
-    if (window.document.getElementById('google-analytics-sdk')) {
-      if (typeof ga !== 'undefined') {
+
+    if (isGa4MeasurementId(trackId)) {
+      if (window.document.getElementById(GA4_SCRIPT_ID)) {
+        if (typeof window.gtag === 'function') {
+          setAnalyticsReady(true)
+        }
+        return
+      }
+
+      window.dataLayer = window.dataLayer || []
+      if (typeof window.gtag !== 'function') {
+        window.gtag = function gtag () {
+          window.dataLayer.push(arguments)
+        }
+      }
+      window.gtag('js', new Date())
+      window.gtag('config', trackId)
+
+      const script = window.document.createElement('script')
+      script.id = GA4_SCRIPT_ID
+      script.async = true
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(trackId)}`
+      script.onload = () => {
+        setAnalyticsReady(true)
+      }
+      window.document.head.appendChild(script)
+      return () => {
+        script.onload = null
+      }
+    }
+
+    if (window.document.getElementById(UA_SCRIPT_ID)) {
+      if (typeof window.ga !== 'undefined') {
         setAnalyticsReady(true)
       }
       return
     }
 
     const js = window.document.createElement('script')
-    js.id = 'google-analytics-sdk'
+    js.id = UA_SCRIPT_ID
     js.async = true
-    js.defer = true
     js.src = 'https://www.google-analytics.com/analytics.js'
-    js.onload = window?.ga && function () {
+    js.onload = () => {
+      if (typeof window.ga === 'undefined') {
+        return
+      }
       setAnalyticsReady(true)
-      window.ga('create', trackId)
+      window.ga('create', trackId, 'auto')
       window.ga('require', 'ec')
       window.ga('set', 'page', window.location.pathname)
       window.ga('send', 'pageview')
@@ -41,65 +80,145 @@ export const Analytics = (props) => {
     }
   }, [trackId])
 
-  /**
-   * Method to handle Pageview send to analytics
-   * @param {String} pageName
-   */
-  const handlechangeView = (pageName) => {
-    window.ga('set', 'page', pageName?.page)
-    window.ga('send', 'pageview')
-  }
-  const handleClickProduct = (product) => {
-    window.ga('ec:addProduct', {
-      id: product.id,
-      name: product.name,
-      category: product.category_id,
-      price: product.price
-    })
-    window.ga('ec:setAction', 'click')
-    window.ga('send', 'event', 'UI', 'click', 'add to cart')
-  }
-  const handleProductAdded = (product) => {
-    window.ga('ec:addProduct', {
-      id: product.id,
-      name: product.name,
-      category: product.category_id,
-      price: product.price,
-      quantity: product.quantity
-    })
-    window.ga('ec:setAction', 'add')
-    window.ga('send', 'event', 'UI', 'click', 'add to cart')
-  }
-  const handleLogin = (data) => {
-    window.ga('set', 'userId', data.id)
-  }
-  const handleOrderPlaced = (order) => {
-    window.ga('ec:setAction', 'purchase', { // Transaction details are provided in an actionFieldObject.
-      id: order.id, // (Required) Transaction id (string).
-      affiliation: order.business?.name, // Affiliation (string).
-      revenue: order.total, // Revenue (number).
-      tax: order.tax_total, // Tax (number).
-      shipping: order.delivery_zone_price // Shipping (number).
-    })
-  }
+  const handlechangeView = useCallback((pageName) => {
+    const path = pageName?.page ?? window.location.pathname
+    if (isGa4MeasurementId(trackId) && typeof window.gtag === 'function') {
+      window.gtag('event', 'page_view', {
+        page_path: path,
+        page_location: window.location.href
+      })
+      return
+    }
+    if (typeof window.ga !== 'undefined') {
+      window.ga('set', 'page', path)
+      window.ga('send', 'pageview')
+    }
+  }, [trackId])
+
+  const handleClickProduct = useCallback((product) => {
+    if (isGa4MeasurementId(trackId) && typeof window.gtag === 'function') {
+      window.gtag('event', 'select_item', {
+        items: [{
+          item_id: String(product.id),
+          item_name: product.name,
+          item_category: product.category_id != null ? String(product.category_id) : undefined,
+          price: Number(product.price) || 0
+        }]
+      })
+      return
+    }
+    if (typeof window.ga !== 'undefined') {
+      window.ga('ec:addProduct', {
+        id: product.id,
+        name: product.name,
+        category: product.category_id,
+        price: product.price
+      })
+      window.ga('ec:setAction', 'click')
+      window.ga('send', 'event', 'UI', 'click', 'add to cart')
+    }
+  }, [trackId])
+
+  const handleProductAdded = useCallback((product) => {
+    const quantity = Number(product.quantity) || 1
+    const price = Number(product.price) || 0
+    if (isGa4MeasurementId(trackId) && typeof window.gtag === 'function') {
+      window.gtag('event', 'add_to_cart', {
+        currency: 'USD',
+        value: price * quantity,
+        items: [{
+          item_id: String(product.id),
+          item_name: product.name,
+          item_category: product.category_id != null ? String(product.category_id) : undefined,
+          price,
+          quantity
+        }]
+      })
+      return
+    }
+    if (typeof window.ga !== 'undefined') {
+      window.ga('ec:addProduct', {
+        id: product.id,
+        name: product.name,
+        category: product.category_id,
+        price: product.price,
+        quantity: product.quantity
+      })
+      window.ga('ec:setAction', 'add')
+      window.ga('send', 'event', 'UI', 'click', 'add to cart')
+    }
+  }, [trackId])
+
+  const handleLogin = useCallback((data) => {
+    if (isGa4MeasurementId(trackId) && typeof window.gtag === 'function') {
+      window.gtag('config', trackId, { user_id: String(data.id) })
+      return
+    }
+    if (typeof window.ga !== 'undefined') {
+      window.ga('set', 'userId', data.id)
+    }
+  }, [trackId])
+
+  const handleOrderPlaced = useCallback((order) => {
+    if (isGa4MeasurementId(trackId) && typeof window.gtag === 'function') {
+      const value = parseFloat(order.total) || 0
+      window.gtag('event', 'purchase', {
+        transaction_id: String(order.id),
+        value,
+        tax: parseFloat(order.tax_total) || 0,
+        shipping: parseFloat(order.delivery_zone_price) || 0,
+        currency: order.currency || 'USD',
+        affiliation: order.business?.name
+      })
+      return
+    }
+    if (typeof window.ga !== 'undefined') {
+      window.ga('ec:setAction', 'purchase', {
+        id: order.id,
+        affiliation: order.business?.name,
+        revenue: order.total,
+        tax: order.tax_total,
+        shipping: order.delivery_zone_price
+      })
+      window.ga('send', 'pageview')
+    }
+  }, [trackId])
+
   useEffect(() => {
-    if (analyticsReady && window.ga) {
-      events.on('change_view', handlechangeView)
-      events.on('userLogin', handleLogin)
-      events.on('product_clicked', handleClickProduct)
-      events.on('product_added', handleProductAdded)
-      events.on('order_placed', handleOrderPlaced)
+    if (!analyticsReady || isDisabledTrackId(trackId)) {
+      return
     }
+
+    const canUseGa4 = isGa4MeasurementId(trackId) && typeof window.gtag === 'function'
+    const canUseUa = !isGa4MeasurementId(trackId) && typeof window.ga !== 'undefined'
+    if (!canUseGa4 && !canUseUa) {
+      return
+    }
+
+    events.on('change_view', handlechangeView)
+    events.on('userLogin', handleLogin)
+    events.on('product_clicked', handleClickProduct)
+    events.on('product_added', handleProductAdded)
+    events.on('order_placed', handleOrderPlaced)
+
     return () => {
-      if (analyticsReady && window.ga) {
-        events.off('change_view', handlechangeView)
-        events.off('userLogin', handleLogin)
-        events.off('product_clicked', handleClickProduct)
-        events.off('product_added', handleProductAdded)
-        events.off('order_placed', handleOrderPlaced)
-      }
+      events.off('change_view', handlechangeView)
+      events.off('userLogin', handleLogin)
+      events.off('product_clicked', handleClickProduct)
+      events.off('product_added', handleProductAdded)
+      events.off('order_placed', handleOrderPlaced)
     }
-  }, [analyticsReady])
+  }, [
+    analyticsReady,
+    trackId,
+    events,
+    handlechangeView,
+    handleLogin,
+    handleClickProduct,
+    handleProductAdded,
+    handleOrderPlaced
+  ])
+
   return (
     <>
       {children}
@@ -109,8 +228,7 @@ export const Analytics = (props) => {
 
 Analytics.propTypes = {
   /**
-   * Your Google Analytics trackId
-   * @see trackId What is trackID ? https://developers.google.com/analytics/devguides/collection/analyticsjs
+   * Google Analytics ID: GA4 Measurement ID (G-xxxxxxxxxx) or legacy Universal Analytics (UA-xxxxxxxx-x).
    */
   trackId: PropTypes.string.isRequired
 }


### PR DESCRIPTION
Fixes ORD-1193

## Summary
- backport existing GA4 Measurement ID support without releasing unrelated `main` changes
- preserve Universal Analytics compatibility
- align regression coverage with GA4 page, product, login, and purchase events

## Test Plan
- [x] `yarn test src/components/Analitycs/__tests__/Analytics.test.jsx`
- [x] Confirm GA4 uses `google-analytics-gtag`
- [x] Confirm legacy UA IDs continue using `analytics.js`

Made with [Cursor](https://cursor.com)