### PR TITLE
fix(native): export parseBusinessDateTime from the RN barrel

### DIFF
--- a/native/index.js
+++ b/native/index.js
@@ -117,7 +117,7 @@ import {
   sortSubcategoriesByRank
 } from '../src/utils/subcategoryProductSort'
 import { CODES } from '../src/constants/code-numbers'
-import { TIMEZONES, createDayjsWithTimezone } from '../src/constants/timezones'
+import { TIMEZONES, createDayjsWithTimezone, parseBusinessDateTime } from '../src/constants/timezones'
 import { useSchoolStudents } from '../src/hooks/useSchoolStudents'
 import { useCartStudent } from '../src/hooks/useCartStudent'
 import { useSchools } from '../src/hooks/useSchools'
@@ -279,6 +279,7 @@ export {
   CODES,
   TIMEZONES,
   createDayjsWithTimezone,
+  parseBusinessDateTime,
   SCHOOL_ALLERGENS,
   SCHOOL_DIETARY_TAGS
 }


### PR DESCRIPTION
## Summary

Re-export the existing `parseBusinessDateTime` helper from the React Native barrel (`native/index.js`), alongside `TIMEZONES` and `createDayjsWithTimezone`.

Two lines, no behaviour change in this repo.

## Why

`parseBusinessDateTime` already lives in `src/constants/timezones` and is what `MomentOption`'s controller uses to turn a business wall-clock slot into an instant:

```js
const _moment = business?.timezone
  ? parseBusinessDateTime(dateSelected, time, business.timezone).toDate()
  : dayjs(`${dateSelected} ${time}`, 'YYYY-MM-DD HH:mm').toDate()
```

But the RN barrel never exposed it, so React Native consumers could not reach it and had to re-implement the conversion.

That is exactly what went wrong in the app-marketplace preorder screen (ORD-1428). The UI grew a second implementation that resolved timezones differently from this one — passing the raw timezone to `dayjs.tz` and falling back to **device-local** parsing on error, instead of routing through `getValidTimezone` and its **UTC** fallback. The two sides computed different strings for the same slot, the equality check that ends the loading state never passed, and the Continue button spun forever.

Exposing the helper lets the UI and the controller share one implementation and one fallback, which is what actually removes that class of bug rather than patching one instance of it.

## Consumer

Paired with [Finitless-com/ordering-app-marketplace-v26#126](https://github.com/Finitless-com/ordering-app-marketplace-v26/pull/126), which drops its local copy in favour of this export. That PR pins the submodule at this branch's commit; it needs a re-point to `main` once this merges.

## Notes

- Branched off the commit the app currently pins (`30340ce`) rather than latest `main`, so the app-side pointer bump stays limited to this change. `native/index.js` is untouched between the two, so this merges cleanly.
- Linear: [ORD-1428](https://linear.app/finitless/issue/ORD-1428/bug-report-infinite-loading-when-setting-preorder-time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)